### PR TITLE
feat: enable release branch option for tag action

### DIFF
--- a/.github/actions/version-release/action.yml
+++ b/.github/actions/version-release/action.yml
@@ -4,6 +4,10 @@ inputs:
   github-token:
     required: true
     description: "your GITHUB_TOKEN"
+  release-branch:
+    required: false
+    description: "The branch the tag should be generated from (default: main)"
+    default: "main"
   version-bump:
     required: false
     description: "major, minor, or patch version bump"
@@ -22,6 +26,7 @@ runs:
       with:
         github_token: ${{ inputs.github-token }}
         default_bump: ${{ inputs.version-bump }}
+        release_branches: ${{ inputs.release-branch }}
     - name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ teams will be added.
 By default, all teams have `Triage` access to all repositories in the
 `rollkit` Github. This allows for anyone to help manage issues and pull
 requests (i.e. adding labels). Teams are given write access to the repositories
-that they are responsible for working on. 
+that they are responsible for working on.
 
 ### Codeowners
 


### PR DESCRIPTION


## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
related to https://github.com/rollkit/rollkit/issues/1362 

this change has already been implemented and verified in celestia-app and celestia-node. 

This flag is required when making releases not on `main` or `master` branches.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `release-branch` parameter to specify the branch for tag generation in the release workflow.

- **Documentation**
  - Minor formatting improvements by removing trailing spaces.

- **Chores**
  - Cleaned up redundant formatting issues in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->