### PR TITLE
fix(ci): remove unsupported linux/arm64

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -268,34 +268,8 @@ jobs:
         if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/setup-buildx-action@v3
 
-      # Build and Publish images on main, master, and versioned branches.
-      #
-      # The reason we split out these steps into 2 is for better handling of
-      # forks when building amd64 images and to enable faster availability of
-      # the amd64 image since building the arm64 image takes significantly
-      # longer.
-      - name: "Merge on Main Trigger: Build and Push All Docker Images"
-        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true'}}
-        uses: docker/build-push-action@v5
-        env:
-          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
-          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
-        with:
-          context: ${{ inputs.dockerContext}}
-          platforms: linux/arm64,linux/amd64
-          provenance: false
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: ${{ inputs.dockerfile }}
-
-      # Build amd64 images always, and publish when it is not a fork. The Github
-      # security model prevents forks from pushing to the registry so we can
-      # only push if the branch/PR is not generated from a fork. Even though
-      # forks can't push, we still want to try and build the image to catch
-      # bugs. For testing purposes we only need an amd64 image.
-      - name: "Pull Request Trigger: Build and Push amd64 Docker Image"
-        if: ${{ needs.prepare-env.outputs.build_for_pr == 'true' && steps.run_check.outputs.run == 'true'}}
+      - name: "Build and Push amd64 Docker Image"
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/build-push-action@v5
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

We don't support arm64 currently so removing it from the docker build

We will want to create a release after this. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the Docker workflow by focusing on building and pushing the amd64 Docker image under specific conditions.
  - Removed unnecessary logic for building and publishing images on certain branches.
  - Updated job naming and conditions for better clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->