### PR TITLE
feat: comment out Trivy as it was info only and has been failing for rate limits

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -142,48 +142,48 @@ jobs:
           echo "Failing step due to build_for_pr == build_for_merge"
           exit 1
 
-  docker-security:
-    needs: ["prepare-env", "logic-check"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout
-        uses: "actions/checkout@v4"
+  # docker-security:
+  #   needs: ["prepare-env", "logic-check"]
+  #   runs-on: "ubuntu-latest"
+  #   steps:
+  #     - name: Checkout
+  #       uses: "actions/checkout@v4"
 
-      - name: Build
-        uses: docker/build-push-action@v5
-        env:
-          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
-          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
-        with:
-          context: ${{ inputs.dockerContext}}
-          push: false
-          platforms: linux/amd64
-          # we're building the container before the scan, use the short sha tag
-          # for referring to it later
-          tags: ${{ env.OUTPUT_IMAGE_NAME }}:${{ env.OUTPUT_SHORT_SHA }}
-          file: ${{ inputs.dockerfile }}
+  #     - name: Build
+  #       uses: docker/build-push-action@v5
+  #       env:
+  #         OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
+  #         OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
+  #       with:
+  #         context: ${{ inputs.dockerContext}}
+  #         push: false
+  #         platforms: linux/amd64
+  #         # we're building the container before the scan, use the short sha tag
+  #         # for referring to it later
+  #         tags: ${{ env.OUTPUT_IMAGE_NAME }}:${{ env.OUTPUT_SHORT_SHA }}
+  #         file: ${{ inputs.dockerfile }}
 
-      - name: Run Trivy vulnerability scanner
-        # source: https://github.com/aquasecurity/trivy-action
-        # https://github.com/marketplace/actions/aqua-security-trivy
-        uses: aquasecurity/trivy-action@master
-        env:
-          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
-          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
-        with:
-          # here we use the local tag that we've built before
-          image-ref: "${{ env.OUTPUT_IMAGE_NAME }}:${{ env.OUTPUT_SHORT_SHA }}"
-          format: "table"
-          #exit-code: '1' # uncomment to stop the CI if the scanner fails
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+  #     - name: Run Trivy vulnerability scanner
+  #       # source: https://github.com/aquasecurity/trivy-action
+  #       # https://github.com/marketplace/actions/aqua-security-trivy
+  #       uses: aquasecurity/trivy-action@master
+  #       env:
+  #         OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
+  #         OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
+  #       with:
+  #         # here we use the local tag that we've built before
+  #         image-ref: "${{ env.OUTPUT_IMAGE_NAME }}:${{ env.OUTPUT_SHORT_SHA }}"
+  #         format: "table"
+  #         #exit-code: '1' # uncomment to stop the CI if the scanner fails
+  #         ignore-unfixed: true
+  #         vuln-type: "os,library"
+  #         severity: "CRITICAL,HIGH"
 
   docker-build:
     name: docker-build (${{ matrix.registry.name }}; ${{ matrix.registry.registry-url }}/${{ matrix.registry.registry-owner }}/${{ needs.prepare-env.outputs.output_image_name }})
     runs-on: "ubuntu-latest"
     # wait until the jobs are finished.
-    needs: ["prepare-env", "logic-check", "docker-security"]
+    needs: ["prepare-env", "logic-check"]
     # We only want to run this step if one of the build flags is true. We don't
     # run if both logic flags are false. This is the case for push events on PR
     # commits. The logic-check job protects us from the case of both build flags


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Example failure: https://github.com/rollkit/rollkit/actions/runs/11692820719/job/32563038100?pr=1911

We already applied this change in the celestiaorg. 

Main reason for commenting it out is because it is something we would like to re-enable in the future once we have time to figure out the ratelimiting. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled the `docker-security` job, which included Docker image building and vulnerability scanning.
	- Updated job dependencies for the `docker-build` process to streamline workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->